### PR TITLE
Cleanup and add core

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -1,25 +1,26 @@
 #!/usr/bin/env bash
+set -eux
 
 if [ -z "$BRAVE_VERSIONS" ]; then
     echo "Need to set BRAVE_VERSIONS to at least one brave/electron version"
     exit 1
 fi
 
-for VERSION in `echo $BRAVE_VERSIONS`
+for VERSION in $BRAVE_VERSIONS
 do
+    # shellcheck disable=SC2086
+    mkdir -p symbols/{win32-ia32-$VERSION,win32-x64-$VERSION,darwin-$VERSION,linux-$VERSION}
 
-	mkdir -p symbols/{win32-ia32-$VERSION,win32-x64-$VERSION,darwin-$VERSION,linux-$VERSION}
-
-	if [ `which bsdtar` ] && [ ! $FORCE_UNZIP ]; then
-		cmd="bsdtar -xvf-"
-		( cd symbols/win32-ia32-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip | $cmd )
-		( cd symbols/win32-x64-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip | $cmd )
-		( cd symbols/darwin-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip | $cmd )
-	elif [ `which unzip` ]; then
-		cmd="unzip -x"
-		( cd symbols/win32-ia32-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip )
-		( cd symbols/win32-x64-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip )
-		( cd symbols/darwin-$VERSION ; wget -O - https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip > /tmp/darwin.zip ; $cmd /tmp/darwin.zip )
-	fi
+    if [ "$(which bsdtar)" ] && [ ! "$FORCE_UNZIP" ]; then
+        cmd="bsdtar -xvf-"
+        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" | $cmd )
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
+    elif [ "$(which unzip)" ]; then
+        cmd="unzip -x"
+        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip ; rm /tmp/win32-ia32.zip)
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
+    fi
 
 done

--- a/fetch.sh
+++ b/fetch.sh
@@ -1,26 +1,48 @@
 #!/usr/bin/env bash
 set -eux
 
-if [ -z "$BRAVE_VERSIONS" ]; then
-    echo "Need to set BRAVE_VERSIONS to at least one brave/electron version"
+MUON_URL="https://github.com/brave/electron/releases/download"
+CORE_URL="https://github.com/brave/brave-browser-builds/releases/download"
+
+MUON_VERSIONS="${MUON_VERSIONS:-}"
+CORE_VERSIONS="${CORE_VERSIONS:-}"
+
+if [ -z "$MUON_VERSIONS" ] && [ -z "$CORE_VERSIONS" ]; then
+    echo "Error, missing MUON_VERSIONS or CORE_VERSIONS environment variables. Please set."
     exit 1
 fi
 
-for VERSION in $BRAVE_VERSIONS
+echo $CORE_URL
+
+for VERSION in $MUON_VERSIONS
 do
     # shellcheck disable=SC2086
     mkdir -p symbols/{win32-ia32-$VERSION,win32-x64-$VERSION,darwin-$VERSION,linux-$VERSION}
 
     if [ "$(which bsdtar)" ] && [ ! "$FORCE_UNZIP" ]; then
         cmd="bsdtar -xvf-"
-        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" | $cmd )
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
+        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" | $cmd )
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
     elif [ "$(which unzip)" ]; then
         cmd="unzip -x"
-        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip ; rm /tmp/win32-ia32.zip)
-        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
-        ( cd "symbols/darwin-$VERSION" ; wget -O - "https://github.com/brave/electron/releases/download/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
+        ( cd "symbols/win32-ia32-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-ia32-symbols.zip" > /tmp/win32-ia32.zip ; $cmd /tmp/win32-ia32.zip ; rm /tmp/win32-ia32.zip)
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "$MUON_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
     fi
+done
 
+for VERSION in $CORE_VERSIONS
+do
+    # shellcheck disable=SC2086
+    mkdir -p symbols/{win32-ia32-$VERSION,win32-x64-$VERSION,darwin-$VERSION,linux-$VERSION}
+    if [ "$(which bsdtar)" ] && [ ! "$FORCE_UNZIP" ]; then
+        cmd="bsdtar -xvf-"
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" | $cmd )
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" | $cmd )
+    elif [ "$(which unzip)" ]; then
+        cmd="unzip -x"
+        ( cd "symbols/win32-x64-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-win32-x64-symbols.zip" > /tmp/win32-x64.zip ; $cmd /tmp/win32-x64.zip ; rm /tmp/win32-x64.zip)
+        ( cd "symbols/darwin-$VERSION" ; wget -O - "$CORE_URL/v${VERSION}/brave-v${VERSION}-darwin-x64-symbols.zip" > /tmp/darwin.zip ; $cmd /tmp/darwin.zip ; rm /tmp/darwin.zip)
+    fi
 done


### PR DESCRIPTION
This PR contains 2 commits.

The first commit cleans up the fetch.sh script so that it passes shellcheck tests, but still works as expected.

The second commit adds support for fetching both Muon and/or Core debug symbols. The script will only exit out if neither has been specified.